### PR TITLE
Improved Version References In Docker-compose.yml files

### DIFF
--- a/docker-compose.service-deps.yml
+++ b/docker-compose.service-deps.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   postgres:
-    image: "postgres"
+    image: library/postgres:13-alpine
     restart: always
     env_file:
       - ./env/dev/database.env
@@ -10,7 +10,7 @@ services:
     ports:
       - "5432:5432"
   cassandra:
-      image: cassandra:latest
+      image: library/cassandra:3.11
       ports:
         - "9042:9042"
       environment:
@@ -21,7 +21,7 @@ services:
         - cassandra_data:/var/lib/cassandra
   cassandra-load-keyspace:
       container_name: cassandra-load-keyspace
-      image: cassandra:latest
+      image: library/cassandra:3.11
       depends_on:
         - cassandra
       volumes:
@@ -53,7 +53,7 @@ services:
       - ./service_configs/traefik/certs:/certs
       - ./service_configs/traefik/traefik.toml:/etc/traefik/traefik.toml
   influxdb:
-    image: influxdb:latest
+    image: library/influxdb:1.8.4-alpine
     restart: always
     env_file:
       - ./env/dev/influxdb.env

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   postgres:
-    image: "postgres"
+    image: library/postgres:13-alpine
     env_file:
       - ./env/test/database.env
     volumes:
@@ -9,7 +9,7 @@ services:
     expose:
       - "5432"
   cassandra:
-    image: cassandra:latest
+    image: library/cassandra:3.11
     expose:
       - "9042"
     environment:
@@ -19,7 +19,7 @@ services:
     volumes:
       - cassandra_data:/var/lib/cassandra
   cassandra-load-keyspace:
-      image: cassandra:latest
+      image: cassandra:3.11
       depends_on:
         - cassandra
       volumes:
@@ -39,7 +39,7 @@ services:
     env_file: 
       - ./env/test/grafana.env
   influxdb:
-    image: influxdb:latest
+    image: library/influxdb:1.8.4-alpine
     env_file:
       - ./env/test/influxdb.env
     expose:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - postgres
       - kafka
   cassandra:
-    image: cassandra:latest
+    image: cassandra:3.11
     expose:
       - "9042"
     environment:
@@ -52,7 +52,7 @@ services:
       - ./service_configs/traefik/certs:/certs
       - ./service_configs/traefik/traefik.toml:/etc/traefik/traefik.toml
   influxdb:
-    image: influxdb:latest
+    image: library/influxdb:1.8.4-alpine
     env_file:
       - ./env/prd/influxdb.env
     expose:
@@ -62,7 +62,7 @@ services:
       - ./service_configs/influxdb/influxdb.conf:/etc/influxdb/influxdb.conf:ro
       - ./service_configs/influxdb/init:/docker-entrypoint-initdb.d
   postgres:
-    image: "postgres"
+    image: library/postgres:13-alpine
     env_file:
       - ./env/prd/database.env
     volumes:


### PR DESCRIPTION
Avoids usage of latest in third party services in docker-compose.yml files in favor of pinned versions with a few exceptions excluding patch version.